### PR TITLE
Optimize `get` and `get_if`

### DIFF
--- a/include/yk/rvariant/detail/visit.hpp
+++ b/include/yk/rvariant/detail/visit.hpp
@@ -25,6 +25,11 @@ namespace yk {
 
 namespace detail {
 
+[[noreturn]] inline void throw_bad_variant_access()
+{
+    throw std::bad_variant_access{};
+}
+
 // TODO: apply same logic to other visits with >= O(n^2) branch
 inline constexpr std::size_t visit_instantiation_limit = 1024;
 
@@ -397,7 +402,7 @@ struct multi_visitor<std::index_sequence<Is...>>
         YK_RVARIANT_VISIT_NOEXCEPT(multi_visit_noexcept<R, std::index_sequence<Is...>, Visitor, Storage...>::value)
     {
         if constexpr (((!std::remove_cvref_t<Storage>::never_valueless && Is == 0) || ...)) {
-            throw std::bad_variant_access{};
+            detail::throw_bad_variant_access();
 
         } else {
 #define YK_MULTI_VISITOR_INVOKE \

--- a/include/yk/rvariant/rvariant.hpp
+++ b/include/yk/rvariant/rvariant.hpp
@@ -875,7 +875,7 @@ YK_RVARIANT_ALWAYS_THROWING_UNREACHABLE_END
                 } else {
                     constexpr std::size_t j = detail::subset_reindex<rvariant, rvariant<Us...>>(i);
                     if constexpr (j == core::find_npos) {
-                        throw std::bad_variant_access{};
+                        detail::throw_bad_variant_access();
                     } else {
                         return rvariant<Us...>(std::in_place_index<j>, ti);
                     }
@@ -916,7 +916,7 @@ YK_RVARIANT_ALWAYS_THROWING_UNREACHABLE_END
                 } else {
                     constexpr std::size_t j = detail::subset_reindex<rvariant, rvariant<Us...>>(i);
                     if constexpr (j == core::find_npos) {
-                        throw std::bad_variant_access{};
+                        detail::throw_bad_variant_access();
                     } else {
                         static_assert(std::is_rvalue_reference_v<Ti&&>);
                         return rvariant<Us...>(std::in_place_index<j>, std::move(ti)); // NOLINT(bugprone-move-forwarding-reference)
@@ -1070,32 +1070,44 @@ template<std::size_t I, class... Ts>
 [[nodiscard]] constexpr variant_alternative_t<I, rvariant<Ts...>>&
 get(rvariant<Ts...>& v YK_LIFETIMEBOUND)
 {
-    if (I != v.index()) throw std::bad_variant_access{};
-    return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&>(v)));
+    static_assert(I < sizeof...(Ts));
+    if (v.index() == I) {
+        return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&>(v)));
+    }
+    detail::throw_bad_variant_access();
 }
 
 template<std::size_t I, class... Ts>
 [[nodiscard]] constexpr variant_alternative_t<I, rvariant<Ts...>>&&
 get(rvariant<Ts...>&& v YK_LIFETIMEBOUND)  // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
 {
-    if (I != v.index()) throw std::bad_variant_access{};
-    return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&&>(v)));
+    static_assert(I < sizeof...(Ts));
+    if (v.index() == I) {
+        return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&&>(v)));
+    }
+    detail::throw_bad_variant_access();
 }
 
 template<std::size_t I, class... Ts>
 [[nodiscard]] constexpr variant_alternative_t<I, rvariant<Ts...>> const&
 get(rvariant<Ts...> const& v YK_LIFETIMEBOUND)
 {
-    if (I != v.index()) throw std::bad_variant_access{};
-    return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&>(v)));
+    static_assert(I < sizeof...(Ts));
+    if (v.index() == I) {
+        return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&>(v)));
+    }
+    detail::throw_bad_variant_access();
 }
 
 template<std::size_t I, class... Ts>
 [[nodiscard]] constexpr variant_alternative_t<I, rvariant<Ts...>> const&&
 get(rvariant<Ts...> const&& v YK_LIFETIMEBOUND)
 {
-    if (I != v.index()) throw std::bad_variant_access{};
-    return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&&>(v)));
+    static_assert(I < sizeof...(Ts));
+    if (v.index() == I) {
+        return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&&>(v)));
+    }
+    detail::throw_bad_variant_access();
 }
 
 template<class T, class... Ts>
@@ -1103,8 +1115,10 @@ template<class T, class... Ts>
 get(rvariant<Ts...>& v YK_LIFETIMEBOUND)
 {
     constexpr std::size_t I = detail::exactly_once_index_v<T, rvariant<Ts...>>;
-    if (v.index() != I) throw std::bad_variant_access{};
-    return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&>(v)));
+    if (v.index() == I) {
+        return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&>(v)));
+    }
+    detail::throw_bad_variant_access();
 }
 
 template<class T, class... Ts>
@@ -1112,8 +1126,10 @@ template<class T, class... Ts>
 get(rvariant<Ts...>&& v YK_LIFETIMEBOUND)  // NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved)
 {
     constexpr std::size_t I = detail::exactly_once_index_v<T, rvariant<Ts...>>;
-    if (v.index() != I) throw std::bad_variant_access{};
-    return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&&>(v)));
+    if (v.index() == I) {
+        return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&&>(v)));
+    }
+    detail::throw_bad_variant_access();
 }
 
 template<class T, class... Ts>
@@ -1121,8 +1137,10 @@ template<class T, class... Ts>
 get(rvariant<Ts...> const& v YK_LIFETIMEBOUND)
 {
     constexpr std::size_t I = detail::exactly_once_index_v<T, rvariant<Ts...>>;
-    if (v.index() != I) throw std::bad_variant_access{};
-    return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&>(v)));
+    if (v.index() == I) {
+        return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&>(v)));
+    }
+    detail::throw_bad_variant_access();
 }
 
 template<class T, class... Ts>
@@ -1130,8 +1148,10 @@ template<class T, class... Ts>
 get(rvariant<Ts...> const&& v YK_LIFETIMEBOUND)
 {
     constexpr std::size_t I = detail::exactly_once_index_v<T, rvariant<Ts...>>;
-    if (v.index() != I) throw std::bad_variant_access{};
-    return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&&>(v)));
+    if (v.index() == I) {
+        return detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&&>(v)));
+    }
+    detail::throw_bad_variant_access();
 }
 
 template<class T, class... Ts>
@@ -1156,16 +1176,20 @@ template<std::size_t I, class... Ts>
 [[nodiscard]] constexpr std::add_pointer_t<variant_alternative_t<I, rvariant<Ts...>>>
 get_if(rvariant<Ts...>* v) noexcept
 {
-    if (v == nullptr || v->index() != I) return nullptr;
-    return std::addressof(detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&>(*v))));
+    static_assert(I < sizeof...(Ts));
+    return v && v->index() == I
+        ? std::addressof(detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...>&>(*v))))
+        : nullptr;
 }
 
 template<std::size_t I, class... Ts>
 [[nodiscard]] constexpr std::add_pointer_t<variant_alternative_t<I, rvariant<Ts...>> const>
 get_if(rvariant<Ts...> const* v) noexcept
 {
-    if (v == nullptr || v->index() != I) return nullptr;
-    return std::addressof(detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&>(*v))));
+    static_assert(I < sizeof...(Ts));
+    return v && v->index() == I
+        ? std::addressof(detail::unwrap_recursive(detail::raw_get<I>(detail::forward_storage<rvariant<Ts...> const&>(*v))))
+        : nullptr;
 }
 
 template<std::size_t I, class... Ts>

--- a/include/yk/rvariant/rvariant_io.hpp
+++ b/include/yk/rvariant/rvariant_io.hpp
@@ -54,7 +54,7 @@ std::ostream& operator<<(std::ostream& os, rvariant<Ts...> const& v)
 
     if (v.valueless_by_exception()) [[unlikely]] {
         // does not set badbit, as per the spec
-        throw std::bad_variant_access(); // always throw, regardless of `os.exceptions()`
+        detail::throw_bad_variant_access(); // always throw, regardless of `os.exceptions()`
     }
 
     try {
@@ -212,7 +212,7 @@ struct formatter<::yk::rvariant<Ts...>, charT>  // NOLINT(cert-dcl58-cpp)
             [&]<std::size_t i, class VT>(std::in_place_index_t<i>, VT const& alt) -> OutIt {
                 if constexpr (i == std::variant_npos) {
                     (void)alt;
-                    throw std::bad_variant_access{};
+                    ::yk::detail::throw_bad_variant_access();
                 } else {
                     return std::format_to(
                         ctx.out(),
@@ -251,7 +251,7 @@ struct formatter<::yk::detail::variant_format_proxy<VFormat, Variant>, charT>  /
             [&]<std::size_t i, class VT>(std::in_place_index_t<i>, VT const& alt) -> OutIt {
                 if constexpr (i == std::variant_npos) {
                     (void)alt;
-                    throw std::bad_variant_access{};
+                    ::yk::detail::throw_bad_variant_access();
                 } else {
                     static_assert(
                         std::is_invocable_v<VFormat, std::in_place_type_t<::yk::unwrap_recursive_t<VT>>>,

--- a/include/yk/rvariant/variant_helper.hpp
+++ b/include/yk/rvariant/variant_helper.hpp
@@ -70,7 +70,7 @@ struct variant_size<rvariant<Ts...>> : std::integral_constant<std::size_t, sizeo
 namespace detail {
 
 template<class T>
-[[nodiscard]] constexpr auto&&
+[[nodiscard]] YK_FORCEINLINE constexpr auto&&
 unwrap_recursive(T&& o YK_LIFETIMEBOUND) noexcept
 {
     if constexpr (core::is_ttp_specialization_of_v<std::remove_cvref_t<T>, recursive_wrapper>) {

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -129,6 +129,72 @@ void benchmark_multi_visit(std::size_t const N, Vars const& vars)
 }
 #endif
 
+template<class Vars>
+void benchmark_get(std::size_t const N, Vars const& vars)
+{
+    unsigned long long sum = 0;
+
+    auto const start_time = Clock::now();
+    for (std::size_t i = 0; i < N; ++i) {
+        switch (vars[i].index()) {
+        case  0: sum += get< 0>(vars[i]); break;
+        case  1: sum += get< 1>(vars[i]); break;
+        case  2: sum += get< 2>(vars[i]); break;
+        case  3: sum += get< 3>(vars[i]); break;
+        case  4: sum += get< 4>(vars[i]); break;
+        case  5: sum += get< 5>(vars[i]); break;
+        case  6: sum += get< 6>(vars[i]); break;
+        case  7: sum += get< 7>(vars[i]); break;
+        case  8: sum += get< 8>(vars[i]); break;
+        case  9: sum += get< 9>(vars[i]); break;
+        case 10: sum += get<10>(vars[i]); break;
+        case 11: sum += get<11>(vars[i]); break;
+        case 12: sum += get<12>(vars[i]); break;
+        case 13: sum += get<13>(vars[i]); break;
+        case 14: sum += get<14>(vars[i]); break;
+        case 15: sum += get<15>(vars[i]); break;
+        default: std::unreachable();
+        }
+    }
+    auto const end_time = Clock::now();
+    auto const elapsed = std::chrono::duration_cast<duration_type>(end_time - start_time);
+    std::println("get: {:.3f} ms", elapsed.count());
+
+    disable_optimization(sum);
+}
+
+template<class Vars>
+YK_FORCEINLINE void benchmark_get_if(std::size_t const N, Vars const& vars)
+{
+    unsigned long long sum = 0;
+
+    auto const start_time = Clock::now();
+    for (std::size_t i = 0; i < N; ++i) {
+        if (auto* ptr = get_if< 0>(&vars[i])) { sum += *ptr; continue; }
+        if (auto* ptr = get_if< 1>(&vars[i])) { sum += *ptr; continue; }
+        if (auto* ptr = get_if< 2>(&vars[i])) { sum += *ptr; continue; }
+        if (auto* ptr = get_if< 3>(&vars[i])) { sum += *ptr; continue; }
+        if (auto* ptr = get_if< 4>(&vars[i])) { sum += *ptr; continue; }
+        if (auto* ptr = get_if< 5>(&vars[i])) { sum += *ptr; continue; }
+        if (auto* ptr = get_if< 6>(&vars[i])) { sum += *ptr; continue; }
+        if (auto* ptr = get_if< 7>(&vars[i])) { sum += *ptr; continue; }
+        if (auto* ptr = get_if< 8>(&vars[i])) { sum += *ptr; continue; }
+        if (auto* ptr = get_if< 9>(&vars[i])) { sum += *ptr; continue; }
+        if (auto* ptr = get_if<10>(&vars[i])) { sum += *ptr; continue; }
+        if (auto* ptr = get_if<11>(&vars[i])) { sum += *ptr; continue; }
+        if (auto* ptr = get_if<12>(&vars[i])) { sum += *ptr; continue; }
+        if (auto* ptr = get_if<13>(&vars[i])) { sum += *ptr; continue; }
+        if (auto* ptr = get_if<14>(&vars[i])) { sum += *ptr; continue; }
+        if (auto* ptr = get_if<15>(&vars[i])) { sum += *ptr; continue; }
+        //std::unreachable(); // makes the entire benchmark slower
+    }
+    auto const end_time = Clock::now();
+    auto const elapsed = std::chrono::duration_cast<duration_type>(end_time - start_time);
+    std::println("get_if: {:.3f} ms", elapsed.count());
+
+    disable_optimization(sum);
+}
+
 template<class Comp, class Vars>
 void benchmark_operator(std::size_t const N, Vars const& vars)
 {
@@ -201,6 +267,9 @@ int benchmark_main(std::size_t const N)
 
         std::vector<V, yk::default_init_allocator<V>> vars;
         benchmark_construct(N, vars);
+
+        benchmark_get(N, vars);
+        benchmark_get_if(N, vars);
         benchmark_visit(N, vars);
 #if YK_CI
         benchmark_multi_visit(N, vars);
@@ -222,6 +291,9 @@ int benchmark_main(std::size_t const N)
 
         std::vector<V, yk::default_init_allocator<V>> vars;
         benchmark_construct(N, vars);
+
+        benchmark_get(N, vars);
+        benchmark_get_if(N, vars);
         benchmark_visit(N, vars);
 #if YK_CI
         benchmark_multi_visit(N, vars);


### PR DESCRIPTION
N: 10000000, alternatives: 16

---

## Before

MSVC 17.14.11
```
[std::variant]
get: 81.819 ms
get_if: 84.347 ms

[yk::rvariant]
get: 83.991 ms
get_if: 74.913 ms
```

GCC 14.2.0
```
[std::variant]
get: 6.882 ms
get_if: 15.638 ms

[yk::rvariant]
get: 7.308 ms
get_if: 12.128 ms
```

Clang 22.0.0 + libc++
```
[std::variant]
get: 79.480 ms
get_if: 6.771 ms

[yk::rvariant]
get: 6.335 ms
get_if: 6.925 ms
```

## After

MSVC 17.14.11
```
[std::variant]
get: 83.246 ms
get_if: 71.798 ms

[yk::rvariant]
get: 82.060 ms
get_if: 69.221 ms
```

GCC 14.2.0
```
[std::variant]
get: 7.836 ms
get_if: 15.467 ms

[yk::rvariant]
get: 6.469 ms
get_if: 13.927 ms
```

Clang 22.0.0 + libc++
```
[std::variant]
get: 79.925 ms
get_if: 7.453 ms

[yk::rvariant]
get: 8.342 ms
get_if: 6.707 ms
```
