### PR TITLE
Remove pointer overloads of `get`

### DIFF
--- a/doc/rvariant.adoc
+++ b/doc/rvariant.adoc
@@ -385,12 +385,6 @@ template<std::size_t I, class... Ts>
 template<std::size_t I, class... Ts>
   constexpr std::add_pointer_t<variant_alternative_t<I, rvariant<Ts...>> const>
     get_if(rvariant<Ts...> const*) noexcept;
-template<std::size_t I, class... Ts>
-  constexpr std::add_pointer_t<variant_alternative_t<I, rvariant<Ts...>>>
-    pass:quotes[[.underline\]#get#](rvariant<Ts...>*) noexcept;       // compatibility with pass:quotes[`boost::get`]
-template<std::size_t I, class... Ts>
-  constexpr std::add_pointer_t<variant_alternative_t<I, rvariant<Ts...>> const>
-    pass:quotes[[.underline\]#get#](rvariant<Ts...> const*) noexcept; // compatibility with pass:quotes[`boost::get`]
 
 template<class T, class... Ts>
   constexpr std::add_pointer_t<T>
@@ -398,12 +392,6 @@ template<class T, class... Ts>
 template<class T, class... Ts>
   constexpr std::add_pointer_t<T const>
     get_if(rvariant<Ts...> const*) noexcept;
-template<class T, class... Ts>
-  constexpr std::add_pointer_t<T>
-    pass:quotes[[.underline\]#get#](rvariant<Ts...>*) noexcept;       // compatibility with pass:quotes[`boost::get`]
-template<class T, class... Ts>
-  constexpr std::add_pointer_t<T const>
-    pass:quotes[[.underline\]#get#](rvariant<Ts...> const*) noexcept; // compatibility with pass:quotes[`boost::get`]
 
 // <<rvariant.visit,[rvariant.visit]>>, visitation
 template<class Visitor, class... Variants>
@@ -1115,14 +1103,6 @@ template<std::size_t I, class... Ts>
 constexpr std::add_pointer_t<variant_alternative_t<I, rvariant<Ts...>> const>
   get_if(rvariant<Ts...> const* v) noexcept;pass:quotes[[.candidate\]#// 2#]
 
-template<std::size_t I, class... Ts>
-constexpr std::add_pointer_t<variant_alternative_t<I, rvariant<Ts...>>>
-  pass:quotes[[.underline\]#get#](rvariant<Ts...>*) noexcept;         // compatibility with pass:quotes[`boost::get`]pass:quotes[[.candidate\]#// 3#]
-
-template<std::size_t I, class... Ts>
-constexpr std::add_pointer_t<variant_alternative_t<I, rvariant<Ts...>> const>
-  pass:quotes[[.underline\]#get#](rvariant<Ts...> const* v) noexcept; // compatibility with pass:quotes[`boost::get`]pass:quotes[[.candidate\]#// 4#]
-
 } // temp_ns
 ----
 
@@ -1130,10 +1110,6 @@ constexpr std::add_pointer_t<variant_alternative_t<I, rvariant<Ts...>> const>
 * [.candidate]#1-2)# *_Mandates:_* `I < sizeof\...(Ts)`.
 +
 *_Returns:_* A pointer to the value [.underline]#denoted by `{UNWRAP_RECURSIVE}(o)`, where `o` denotes a reference to the object stored in the `rvariant`#, if `v != nullptr` and `v\->index() == I`. Otherwise, returns `nullptr`.
-
-* [.candidate]#3-4)# Provided for compatibility with `boost::get`.
-+
-*_Returns:_* `get_if<I>(v)`.
 
 
 [,cpp,subs="+macros,+attributes"]
@@ -1148,14 +1124,6 @@ template<class T, class... Ts>
 constexpr std::add_pointer_t<T const>
   get_if(rvariant<Ts...> const* v) noexcept;pass:quotes[[.candidate\]#// 2#]
 
-template<class T, class... Ts>
-constexpr std::add_pointer_t<T>
-  pass:quotes[[.underline\]#get#](rvariant<Ts...>* v) noexcept;       // compatibility with pass:quotes[`boost::get`]pass:quotes[[.candidate\]#// 3#]
-
-template<class T, class... Ts>
-constexpr std::add_pointer_t<T const>
-  pass:quotes[[.underline\]#get#](rvariant<Ts...> const* v) noexcept; // compatibility with pass:quotes[`boost::get`]pass:quotes[[.candidate\]#// 4#]
-
 } // temp_ns
 ----
 
@@ -1165,10 +1133,6 @@ constexpr std::add_pointer_t<T const>
 *_Effects:_* Equivalent to: `return get_if<__i__>(v);` with _i_ being the zero-based index of `T` in [.underline]#`{unwrap_recursive_t}<Ts>`#.
 +
 *_Remarks:_* [.underline]#This function is defined as deleted if `T` is a specialization of `{recursive_wrapper}`.#
-
-* [.candidate]#3-4)# Provided for compatibility with `boost::get`.
-+
-*_Returns:_* `get_if<T>(v)`.
 
 
 [[rvariant.visit]]

--- a/include/yk/rvariant/rvariant.hpp
+++ b/include/yk/rvariant/rvariant.hpp
@@ -1192,20 +1192,6 @@ get_if(rvariant<Ts...> const* v) noexcept
         : nullptr;
 }
 
-template<std::size_t I, class... Ts>
-[[nodiscard]] constexpr std::add_pointer_t<variant_alternative_t<I, rvariant<Ts...>>>
-get(rvariant<Ts...>* v) noexcept
-{
-    return get_if<I>(v);
-}
-
-template<std::size_t I, class... Ts>
-[[nodiscard]] constexpr std::add_pointer_t<variant_alternative_t<I, rvariant<Ts...>> const>
-get(rvariant<Ts...> const* v) noexcept
-{
-    return get_if<I>(v);
-}
-
 template<class T, class... Ts>
 [[nodiscard]] constexpr std::add_pointer_t<T>
 get_if(rvariant<Ts...>* v) noexcept
@@ -1220,20 +1206,6 @@ get_if(rvariant<Ts...> const* v) noexcept
 {
     constexpr std::size_t I = detail::exactly_once_index_v<T, rvariant<Ts...>>;
     return get_if<I>(v);
-}
-
-template<class T, class... Ts>
-[[nodiscard]] constexpr std::add_pointer_t<T>
-get(rvariant<Ts...>* v) noexcept
-{
-    return get_if<T>(v);
-}
-
-template<class T, class... Ts>
-[[nodiscard]] constexpr std::add_pointer_t<T const>
-get(rvariant<Ts...> const* v) noexcept
-{
-    return get_if<T>(v);
 }
 
 // -------------------------------------------

--- a/test/get_visit_test.cpp
+++ b/test/get_visit_test.cpp
@@ -167,24 +167,10 @@ TEST_CASE("get_if")
     }
     {
         yk::rvariant<int, float> var = 42;
-        REQUIRE(*yk::get<0>(&var) == 42);
-        REQUIRE(*yk::get<0>(&std::as_const(var)) == 42);
-        REQUIRE(yk::get<1>(&var) == nullptr);
-        REQUIRE(yk::get<1>(&std::as_const(var)) == nullptr);
-    }
-    {
-        yk::rvariant<int, float> var = 42;
         REQUIRE(*yk::get_if<int>(&var) == 42);
         REQUIRE(*yk::get_if<int>(&std::as_const(var)) == 42);
         REQUIRE(yk::get_if<float>(&var) == nullptr);
         REQUIRE(yk::get_if<float>(&std::as_const(var)) == nullptr);
-    }
-    {
-        yk::rvariant<int, float> var = 42;
-        REQUIRE(*yk::get<int>(&var) == 42);
-        REQUIRE(*yk::get<int>(&std::as_const(var)) == 42);
-        REQUIRE(yk::get<float>(&var) == nullptr);
-        REQUIRE(yk::get<float>(&std::as_const(var)) == nullptr);
     }
     {
         yk::rvariant<int, MC_Thrower> valueless = make_valueless<int>();
@@ -204,18 +190,8 @@ TEST_CASE("get_if", "[wrapper]")
     }
     {
         yk::rvariant<yk::recursive_wrapper<int>, float> var = 42;
-        REQUIRE(*yk::get<0>(&var) == 42);
-        REQUIRE(*yk::get<0>(&std::as_const(var)) == 42);
-    }
-    {
-        yk::rvariant<yk::recursive_wrapper<int>, float> var = 42;
         REQUIRE(*yk::get_if<int>(&var) == 42);
         REQUIRE(*yk::get_if<int>(&std::as_const(var)) == 42);
-    }
-    {
-        yk::rvariant<yk::recursive_wrapper<int>, float> var = 42;
-        REQUIRE(*yk::get<int>(&var) == 42);
-        REQUIRE(*yk::get<int>(&std::as_const(var)) == 42);
     }
 }
 


### PR DESCRIPTION
Based on usage experience, it was found that these overloads can prevent IDEs from deducing the return type of `get` in templated contexts.