### PR TITLE
Add test case for recursive vector

### DIFF
--- a/test/truly_recursive_test.cpp
+++ b/test/truly_recursive_test.cpp
@@ -8,6 +8,9 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <variant>
+#include <vector>
+
 namespace unit_test {
 
 #ifdef _MSC_VER
@@ -108,6 +111,33 @@ TEST_CASE("truly recursive", "[wrapper][recursive]")
             [](double const&) { /* ... */ },
             [](BinaryExpr const&) { /* ... */ },
         });
+    }
+    {
+        struct Array;
+        using Expr = yk::rvariant<int, yk::recursive_wrapper<Array>>;
+        struct Array
+        {
+            std::vector<Expr> items;
+            constexpr bool operator==(Array const&) const noexcept = default; // ok
+        };
+        Array a, b;
+        (void)(a == b);
+    }
+    {
+        struct Array;
+        using Expr = yk::rvariant<int, yk::recursive_wrapper<Array>>;
+        struct Array : std::vector<Expr>
+        {
+            //constexpr bool operator==(Array const&) const noexcept = default; // not working
+
+            constexpr bool operator==(Array const& rhs) const noexcept
+            {
+                // error; recursive instantiation
+                return static_cast<std::vector<Expr> const&>(*this) == static_cast<std::vector<Expr> const&>(rhs);
+            }
+        };
+        Array a, b;
+        (void)(a == b);
     }
 }
 


### PR DESCRIPTION
Publicly inheriting from `std::vector<Expr>` results in infinite recursive instantiation:

```cpp
{
    struct Array;
    using Expr = yk::rvariant<int, yk::recursive_wrapper<Array>>;
    struct Array : std::vector<Expr>
    {
        //constexpr bool operator==(Array const&) const noexcept = default; // not working

        constexpr bool operator==(Array const& rhs) const noexcept
        {
            // error; recursive instantiation
            return static_cast<std::vector<Expr> const&>(*this) == static_cast<std::vector<Expr> const&>(rhs);
        }
    };
    Array a, b;
    (void)(a == b);
}
```

However this works:

```cpp
{
    struct Array;
    using Expr = yk::rvariant<int, yk::recursive_wrapper<Array>>;
    struct Array
    {
        std::vector<Expr> items;
        constexpr bool operator==(Array const&) const noexcept = default; // ok
    };
    Array a, b;
    (void)(a == b);
}
```

Whether this is a bug or intended limitation, I think it should be documented. However I have no idea on why the second code works, so I'm not sure how to document it.

@yaito3014 Do you have any idea what's going on?

related: #43, #45