### PR TITLE
Specify the exact recursive instantiation scenario of atomic constraints on truly recursive types

### DIFF
--- a/doc/rvariant.adoc
+++ b/doc/rvariant.adoc
@@ -1407,7 +1407,7 @@ class recursive_wrapper
   constexpr pass:quotes[[.underline\]#/* not explicit */#] recursive_wrapper();
 
   template<class U = T>
-  constexpr explicit({see-below}) recursive_wrapper(U&& x) noexcept({see-below});
+  constexpr pass:quotes[[.underline\]#/* not explicit */#] recursive_wrapper(U&& x);
 };
 
 // equivalent to the https://eel.is/c+\+draft/indirect[pass:quotes[`std::indirect`]] counterpart
@@ -1462,7 +1462,7 @@ Effectively overrides only the ones listed below; rest are the same as `std::ind
 constexpr pass:quotes[[.underline\]#/* not explicit */#] recursive_wrapper();pass:quotes[[.candidate\]#// 1#]
 
 template<class U = T>
-constexpr explicit({see-below}) recursive_wrapper(U&& u) noexcept({see-below});pass:quotes[[.candidate\]#// 2#]
+constexpr pass:quotes[[.underline\]#/* not explicit */#] recursive_wrapper(U&& u);pass:quotes[[.candidate\]#// 2#]
 ----
 
 [.candidates]
@@ -1475,12 +1475,16 @@ constexpr explicit({see-below}) recursive_wrapper(U&& u) noexcept({see-below});p
 ** -- `std::is_same_v<std::remove_cvref_t<U>, recursive_wrapper>` is `false`, and
 ** -- `std::is_same_v<std::remove_cvref_t<U>, std::in_place_t>` is `false`, and
 ** -- `std::is_default_constructible_v<Allocator>` is `true`, and
-** -- [.underline]#`std::is_convertible_v<U, T>` is `true`, or the expression `T x[] = {std::forward<U>(u)}` (for an imaginary variable `x`) is well-formed in unevaluated context#. (_Note:_ This prevents recursive instantiation of `std::is_constructible`, even for recursive types, while preserving SFINAE-friendliness.)
+** -- [.underline]#`std::is_convertible_v<U, T>` is `true`#.
+
++
+_Note 1:_ [.underline]#This prevents recursive instantiation of `std::is_constructible`#, even for recursive types, while preserving SFINAE-friendliness. This specification is technically viable only because the class template `rvariant` never uses `std::is_convertible` in any of its constructor overloads. As a result, the atomic constraints of `rvariant` and `recursive_wrapper` remain mutually exclusive. However, if a user-defined class depends on _both_ `std::is_constructible` and `std::is_convertible` (for the same `rvariant` specialization), it may trigger recursive instantiation.
+
++
+_Note 2:_ It is currently unknown whether the recursive instantiation scenario described in _Note 1_ can be technically avoided. This note is provided for informational purposes only and does not specify the semantics of `recursive_wrapper`.
 --
 +
 *_Effects:_* Equivalent to the `std::indirect` counterpart. ^link:pass:[https://eel.is/c++draft/indirect.ctor#lib:indirect,constructor______][[spec\]]^
-+
-*_Remarks:_* [.underline]#The explicit specifier is equivalent to `!std::is_convertible_v<U, T>`#.
 
 
 [[rvariant.recursive.helper]]

--- a/include/yk/core/type_traits.hpp
+++ b/include/yk/core/type_traits.hpp
@@ -311,24 +311,11 @@ struct aggregate_initialize_resolution<
 
 } // detail
 
+// We intentionally don't provide the convenient `_t` and `_v` aliases
+// because they would lead to unnecessarily nested instantiation for
+// legitimate infinite recursion errors on recursive types.
 template<class T, class... Ts>
-using aggregate_initialize_resolution_t = typename detail::aggregate_initialize_resolution<void, T, Ts...>::type;
-
-template<class T, class... Ts>
-constexpr std::size_t aggregate_initialize_resolution_index = detail::aggregate_initialize_resolution<void, T, Ts...>::index;
-
-
-template<class T, class U, class Enabled = void>
-struct is_aggregate_initializable : std::false_type {};
-
-template<class T, class U>
-struct is_aggregate_initializable<T, U, std::void_t<decltype(
-    std::declval<detail::aggregate_initialize_overload<0, T>>()(std::declval<U>(), std::declval<U>())
-)>> : std::true_type
-{};
-
-template<class T, class U>
-constexpr bool is_aggregate_initializable_v = is_aggregate_initializable<T, U>::value;
+struct aggregate_initialize_resolution : detail::aggregate_initialize_resolution<void, T, Ts...> {};
 
 
 // https://eel.is/c++draft/function.objects.general

--- a/include/yk/rvariant/recursive_wrapper.hpp
+++ b/include/yk/rvariant/recursive_wrapper.hpp
@@ -68,18 +68,12 @@ public:
             (!std::is_same_v<std::remove_cvref_t<U>, recursive_wrapper>) &&
             (!std::is_same_v<std::remove_cvref_t<U>, std::in_place_t>) &&
             std::is_default_constructible_v<Allocator> &&
-            //std::is_constructible_v<T, U> && // UNIMPLEMENTABLE for recursive types; instantiates infinitely
-            (
-                // Required for `recursive_wrapper<double> i = 3;`
-                std::is_convertible_v<U, T> ||
-
-                // Required for making recursive_wrapper itself SFINAE-friendly;
-                // otherwise `std::is_constructible_v<recursive_wrapper<int>, X>` will be true for any `X`
-                core::is_aggregate_initializable_v<T, U>
-            )
-    constexpr explicit(!std::is_convertible_v<U, T>)
-    recursive_wrapper(U&& u)
-        noexcept(noexcept(base_type(std::forward<U>(u))))
+            //std::is_constructible_v<T, U> // UNIMPLEMENTABLE for recursive types; instantiates infinitely
+            std::is_convertible_v<U, T>
+    constexpr /* not explicit */ recursive_wrapper(U&& u)
+        // This overload is never `noexcept` as it always allocates.
+        // Note that conditionally enabling `noexcept` will lead to
+        // recursive instantiation in some situations.
         : base_type(std::forward<U>(u))
     {}
 

--- a/test/truly_recursive_test.cpp
+++ b/test/truly_recursive_test.cpp
@@ -59,10 +59,35 @@ TEST_CASE("truly recursive", "[wrapper][recursive]")
     {
         // Sanity check
         {
+            using V = std::variant<int>;
+            STATIC_REQUIRE( std::is_constructible_v<V, V>);
+            STATIC_REQUIRE( std::is_constructible_v<V, int>);
+            STATIC_REQUIRE(!std::is_constructible_v<V, double>);
+        }
+        {
+            using V = std::variant<yk::recursive_wrapper<int>>;
+            STATIC_REQUIRE( std::is_constructible_v<V, V>);
+            STATIC_REQUIRE( std::is_constructible_v<V, int>);
+            STATIC_REQUIRE( std::is_constructible_v<V, double>);  // !!true!!
+        }
+        {
             using V = yk::rvariant<yk::recursive_wrapper<int>>;
             STATIC_REQUIRE( std::is_constructible_v<V, V>);
             STATIC_REQUIRE( std::is_constructible_v<V, int>);
             STATIC_REQUIRE( std::is_constructible_v<V, double>);  // !!true!!
+        }
+
+        // Sanity check
+        {
+            struct SubExpr;
+            using Expr = std::variant<int, yk::recursive_wrapper<SubExpr>>;
+            struct SubExpr { Expr expr; };
+
+            STATIC_REQUIRE( std::is_constructible_v<Expr, int>);
+            STATIC_REQUIRE(!std::is_constructible_v<Expr, double>); // false because equally viable
+
+            STATIC_REQUIRE( std::is_constructible_v<SubExpr, int>);
+            STATIC_REQUIRE(!std::is_constructible_v<SubExpr, double>); // false because equally viable
         }
 
         struct SubExpr;


### PR DESCRIPTION
I have finally managed to figure out the strict technical condition required for `rvariant` to be not recursively instantiating the atomic constraints on recursive types. Accordingly, the specification and the implementation has been simplified. 

Documentation has been updated to reflect the discovery, but we still need some user-friendly "tutorial" on constructing truly recursive types (see #43 and #39). This PR focuses on updating the spec, and does not directly solve the existing issues.