### PR TITLE
Split hash.hpp and hash_fwd.hpp

### DIFF
--- a/include/yk/core/hash.hpp
+++ b/include/yk/core/hash.hpp
@@ -6,23 +6,10 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
+#include <yk/core/hash_fwd.hpp>
 #include <yk/core/type_traits.hpp>
 
 #include <type_traits>
-
-#if __cplusplus <= 202302L || (defined(_MSVC_STL_UPDATE) && _MSVC_STL_UPDATE < 202504L) || (defined(__GLIBCXX__) && __GLIBCXX__ < 20241201) || (defined(_LIBCPP_STD_VER) && _LIBCPP_STD_VER < 26)
-#define YK_HAS_STD_HASH_IN_UTILITY 0
-#else
-#define YK_HAS_STD_HASH_IN_UTILITY 1
-#endif
-
-#if YK_HAS_STD_HASH_IN_UTILITY
-#include <utility> // required for hash declaration (in C++26 and later)
-#else
-#include <typeindex> // required for hash declaration
-#endif
-
-#undef YK_HAS_STD_HASH_IN_UTILITY
 
 namespace yk::core {
 

--- a/include/yk/core/hash_fwd.hpp
+++ b/include/yk/core/hash_fwd.hpp
@@ -1,0 +1,21 @@
+#ifndef YK_CORE_HASH_FWD_HPP
+#define YK_CORE_HASH_FWD_HPP
+
+// Copyright 2025 Yaito Kakeyama
+// Copyright 2025 Nana Sakisaka
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <version>
+
+#if __cplusplus <= 202302L || \
+    (defined(_MSVC_STL_UPDATE) && _MSVC_STL_UPDATE < 202504L) || \
+    (defined(__GLIBCXX__) && __GLIBCXX__ < 20241201) || \
+    (defined(_LIBCPP_STD_VER) && _LIBCPP_STD_VER < 26)
+
+# include <typeindex> // pre-C++26
+#else
+# include <utility> // C++26 and later
+#endif
+
+#endif


### PR DESCRIPTION
It turned out that `hash_fwd.hpp` itself is very convenient in application layer, so split it