### PR TITLE
Install libunwind-*-dev for Clang

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -85,7 +85,7 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x ./llvm.sh
           sudo ./llvm.sh ${{ matrix.compiler.version }}
-          sudo apt-get install -y libc++-${{ matrix.compiler.version }}-dev libc++abi-${{ matrix.compiler.version }}-dev
+          sudo apt-get install -y libc++-${{ matrix.compiler.version }}-dev libc++abi-${{ matrix.compiler.version }}-dev libunwind-${{ matrix.compiler.version }}-dev
 
       - name: Setup GCC
         if: matrix.compiler.name == 'GCC'


### PR DESCRIPTION
It seems like at least Clang 21 requires libunwind-*-dev when the linked application is executed. Found during the development of Spirit.X4.