### PR TITLE
Use canonical include path for lifetimebound

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -47,11 +47,6 @@ jobs:
             executable: clang++-21
             stdlib: libc++
             cxxflags: -stdlib=libc++
-          - name: Clang
-            version: 22
-            executable: clang++-22
-            stdlib: libc++
-            cxxflags: -stdlib=libc++
           - name: MSVC
             version: v143
             executable: cl

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Documentation: <https://yaito3014.github.io/rvariant/main/rvariant.html>
 
 ## Supported Environments
 
+NOTE: Clang 22 is temporarily disabled due to its broken implementation
+
 - GCC 14
 - Clang 21-22 (libc++)
 - MSVC (2022)

--- a/include/yk/core/config.hpp
+++ b/include/yk/core/config.hpp
@@ -8,7 +8,7 @@
 #include <version>
 
 #if _MSC_VER
-# include <CppCoreCheck/Warnings.h>
+# include <CodeAnalysis/CppCoreCheck/Warnings.h>
 # pragma warning(default: CPPCORECHECK_LIFETIME_WARNINGS)
 #endif
 


### PR DESCRIPTION
This properly resolves `#pragma once` used in the header.

Required for syncing the include with Spirit.X4